### PR TITLE
Fix exception when building atlas on Unity 2022.2

### DIFF
--- a/Assets/SpriteDicing/Editor/Processors/SpriteBuilder.cs
+++ b/Assets/SpriteDicing/Editor/Processors/SpriteBuilder.cs
@@ -118,8 +118,13 @@ namespace SpriteDicing
 
         private Sprite CreateSprite (string name, Texture texture, Vector2 pivot, Rect renderRect)
         {
+            #if UNITY_2022_2_OR_NEWER
+            // (texture, rect, pivot, pixelsPerUnit, extrude, meshType, border, generateFallbackPhysicsShape, secondaryTexture)
+            var args = new object[] { texture, renderRect, pivot, ppu, (uint)0, SpriteMeshType.Tight, Vector4.zero, false, null };
+            #else
             // (texture, rect, pivot, pixelsPerUnit, extrude, meshType, border, generateFallbackPhysicsShape)
             var args = new object[] { texture, renderRect, pivot, ppu, (uint)0, SpriteMeshType.Tight, Vector4.zero, false };
+            #endif
             var sprite = (Sprite)createSpriteMethod.Invoke(null, args);
             sprite.name = name;
             sprite.SetVertexCount(vertices.Count);


### PR DESCRIPTION
The `CreateSprite` method, that is called using reflection, has added an additional argument in Unity 2022.2 and building a sprite atlas fails with an exception. This just sets the new `secondaryTextures` argument to its default `null` value.

(Looking at the new feature, this makes it possible to define multiple textures per sprite. I guess this could be used in SpriteDicing for single sprites to use dices from multiple atlases? I'm looking into using SpriteDicing in a project with big background textures and not having to pre-split textures could be useful.)